### PR TITLE
PADV-551 - Add initial AWS definitions.

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,0 +1,3 @@
+// Style overrides for MFEs.
+@import 'overrides_learning';
+@import 'overrides_common';

--- a/paragon/_overrides_common.scss
+++ b/paragon/_overrides_common.scss
@@ -1,0 +1,8 @@
+// Gradebook, Profile and Account MFE overrides.
+
+body #root {
+    header.site-header-desktop ~ main,
+    header.site-header-mobile ~ main { // Selector to specifically select the the standard MFE header.
+        min-height: 100vh;
+    }
+}

--- a/paragon/_overrides_learning.scss
+++ b/paragon/_overrides_learning.scss
@@ -1,0 +1,13 @@
+// Style overrides for Learning and Discussion MFE.
+
+body #root {
+    // LEARNING INSTRUCTOR TOOLBAR.
+    div[data-testid="instructor-toolbar"]>div {
+        background-color: $brand !important;
+    }
+
+    // LEARNING MAIN CONTENT.
+    header.learning-header ~ main { // Selector to specifically select the main content of the learning MFE.
+        min-height: 100vh;
+    }
+}

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,0 +1,5 @@
+// General variable definitions.
+
+$brand: #ff9400 !default;
+$primary: #ff9400 !default;
+$info: #ffa11e !default;

--- a/paragon/fonts.scss
+++ b/paragon/fonts.scss
@@ -1,0 +1,1 @@
+// Custom fonts definitions.


### PR DESCRIPTION
## Description:

This PR adds the initial SASS definitions for the Learning, Profile, Account, Discussion and Gradebook MFE.

## Screenshots:
![image](https://github.com/Pearson-Advance/brand-aws-pearson.com/assets/17520199/ebc15814-9cb3-488b-b8e3-1049097661f9)
![image](https://github.com/Pearson-Advance/brand-aws-pearson.com/assets/17520199/c49cacc7-9229-45ab-bb43-9d00998fe2da)
![image](https://github.com/Pearson-Advance/brand-aws-pearson.com/assets/17520199/1ed4a0df-d022-4802-912e-c1efad0d0f5e)
![image](https://github.com/Pearson-Advance/brand-aws-pearson.com/assets/17520199/3f8ecf31-c9bc-45cc-8454-7fcaad509ba1)
![image](https://github.com/Pearson-Advance/brand-aws-pearson.com/assets/17520199/114ffb11-bf0c-44e9-a017-d81c5e011f1b)

## How to test:

- Clone an MFE.
- Install it as follows: npm install @edx/brand@file:../brand-aws-pearson.com/
- Test the MFE: npm run start

## Reviewers:

- [ ] @alexjmpb 
- [ ] @alexjmpb 