### PR TITLE
fix: discussion logo and fonts have been adjusted.

### DIFF
--- a/paragon/_overrides_learning.scss
+++ b/paragon/_overrides_learning.scss
@@ -17,8 +17,22 @@ body #root {
             margin: 1rem 1rem 2rem 1rem;
 
             img {
-                height: 135%;
+                height: 37px;
             }
+        }
+    }
+
+    #main-content {
+        .courseTabsNavigation, nav, a {
+            font-size: 0.875rem;
+        }
+
+        .h2[role="heading"] {
+            font-size: 1.5rem;
+        }
+
+        .btn {
+            font-size: 1rem;
         }
     }
 


### PR DESCRIPTION
## Description:

This PR fixes the logo for the Discussion MFE and adjusts some font sizes.

## Screenshots:

**Before:**
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/5a7b72a6-6cb0-4624-b2e2-a663cd75c6e6)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/4d75f7aa-c01e-430a-918a-f34da27ca130)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/f49e75fd-4282-4d50-a480-74a14de6adc4)

**After:**
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/b642af40-a9d9-40fd-9038-5192901c4d39)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/1ddd712e-d6b0-445a-96c2-4770492c263c)
![image](https://github.com/Pearson-Advance/brand-pearson.com/assets/17520199/f94331dc-5a50-493c-9235-3aad9b04e7da)

## Reviewers:

- [ ] @alexjmpb 